### PR TITLE
Feature/patch token decimals into voucher hub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,22 @@
 # Changelog
 
 ## vNEXT
+
 - Remove references to blockscout v5. (#49)
+- Overrode the decimals function of ERC-20 to set the token's decimal precision to 9, aligning with RLC standards.
 
 ## v1.0.0
 
 ### What's new?
+
 - Allow users to access resources of the iExec network via a sponsorship voucher.
 
 ### More details
+
 - Upgrade Solidity Compiler to `v0.8.27`. (#45)
 - Bump dependencies: (#44)
-    - `@openzeppelin/hardhat-upgrades`, `hardhat`, `ethers`, `prettier`, and others [minor version bump]
-    - `prettier-plugin-organize-imports@4`
+  - `@openzeppelin/hardhat-upgrades`, `hardhat`, `ethers`, `prettier`, and others [minor version bump]
+  - `prettier-plugin-organize-imports@4`
 - Add `getVoucherProxyCodeHash(..)` & `isRefundedTask(..)` view functions. (#43)
 - Add `predictVoucher(..)` & `isVoucher(..)` functions. (#42)
 - Generate UML class diagram for contracts. (#41)
@@ -43,12 +47,12 @@
 - Match orders through voucher. (#12)
 - Add external-hardhat network configuration. (#11)
 - Add voucher credit and SRLC manipulation. (#10)
-    - SRLC and iExec poco is mocked.
-    - set voucher credit as VoucherHub is ERC20.
+  - SRLC and iExec poco is mocked.
+  - set voucher credit as VoucherHub is ERC20.
 - Upgrade configuration: (#9)
-    - Upgrade dependencies: hardhat, husky, iExec Poco.
-    - Ignore mocks in coverage.
-    - Add solidity optimizer and use Bellecour network config.
+  - Upgrade dependencies: hardhat, husky, iExec Poco.
+  - Ignore mocks in coverage.
+  - Add solidity optimizer and use Bellecour network config.
 - Add role-based access control to VoucherHub. (#8)
 - Create voucher from VoucherHub with : type, expiration, authorize list. (#6)
 - Create vouchers with create2. (#5)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## vNEXT
 
 - Remove references to blockscout v5. (#49)
-- Overrode the decimals function of ERC-20 to set the token's decimal precision to 9, aligning with RLC standards.
+- Override the decimals function of ERC-20 to set the token's decimal precision to 9, aligning with RLC standards.
 - Verify VoucherProxy contracts. (#51)
 
 ## v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## vNEXT
 
 - Remove references to blockscout v5. (#49)
-- Override the decimals function of ERC-20 to set the token's decimal precision to 9, aligning with RLC standards.
+- Override the decimals function of ERC-20 to set the token's decimal precision to 9, aligning with RLC standards. (#50)
 - Verify VoucherProxy contracts. (#51)
 
 ## v1.0.0

--- a/contracts/NonTransferableERC20Upgradeable.sol
+++ b/contracts/NonTransferableERC20Upgradeable.sol
@@ -32,4 +32,22 @@ contract NonTransferableERC20Upgradeable is ERC20Upgradeable {
     function transferFrom(address, address, uint256) public pure override returns (bool) {
         revert("NonTransferableERC20Upgradeable: Unsupported transferFrom");
     }
+
+    /**
+     * @dev Returns the number of decimal places used for user representation.
+     *
+     * This function defines how token balances are displayed to users. For example,
+     * if `decimals` is set to `2`, a balance of `505` tokens will be displayed as
+     * `5.05` (`505 / 10 ** 2`).
+     *
+     * By default, the standard ERC-20 `decimals` value is `18`. However, this value
+     * is overridden here to `9` to align with the number of decimal places used by
+     * the RLC token. This ensures consistency in how input values are handled
+     * when a voucher is minted.
+     *
+     * @return The number of decimal places (9) used for token representation.
+     */
+    function decimals() public pure override returns (uint8) {
+        return 9;
+    }
 }

--- a/contracts/NonTransferableERC20Upgradeable.sol
+++ b/contracts/NonTransferableERC20Upgradeable.sol
@@ -11,6 +11,20 @@ import {ERC20Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/
  */
 contract NonTransferableERC20Upgradeable is ERC20Upgradeable {
     /**
+     * @dev By default, the standard ERC-20 `decimals` value is `18`. However, this value
+     * is overridden here to `9` to align with the number of decimal places used by
+     * the RLC token. This ensures consistency in how input values are handled
+     * when a voucher is minted.
+     *
+     * See https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC20/ERC20.sol#L78
+     *
+     * @return The number of decimal places (9) used for token representation.
+     */
+    function decimals() public pure override returns (uint8) {
+        return 9;
+    }
+
+    /**
      * @notice NonTransferableERC20Upgradeable is not transferable.
      */
     function transfer(address, uint256) public pure override returns (bool) {
@@ -31,19 +45,5 @@ contract NonTransferableERC20Upgradeable is ERC20Upgradeable {
      */
     function transferFrom(address, address, uint256) public pure override returns (bool) {
         revert("NonTransferableERC20Upgradeable: Unsupported transferFrom");
-    }
-
-    /**
-     * @dev By default, the standard ERC-20 `decimals` value is `18`. However, this value
-     * is overridden here to `9` to align with the number of decimal places used by
-     * the RLC token. This ensures consistency in how input values are handled
-     * when a voucher is minted.
-     *
-     * See https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC20/ERC20.sol#L78
-     *
-     * @return The number of decimal places (9) used for token representation.
-     */
-    function decimals() public pure override returns (uint8) {
-        return 9;
     }
 }

--- a/contracts/NonTransferableERC20Upgradeable.sol
+++ b/contracts/NonTransferableERC20Upgradeable.sol
@@ -34,16 +34,12 @@ contract NonTransferableERC20Upgradeable is ERC20Upgradeable {
     }
 
     /**
-     * @dev Returns the number of decimal places used for user representation.
-     *
-     * This function defines how token balances are displayed to users. For example,
-     * if `decimals` is set to `2`, a balance of `505` tokens will be displayed as
-     * `5.05` (`505 / 10 ** 2`).
-     *
-     * By default, the standard ERC-20 `decimals` value is `18`. However, this value
+     * @dev By default, the standard ERC-20 `decimals` value is `18`. However, this value
      * is overridden here to `9` to align with the number of decimal places used by
      * the RLC token. This ensures consistency in how input values are handled
      * when a voucher is minted.
+     *
+     * See https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC20/ERC20.sol#L78
      *
      * @return The number of decimal places (9) used for token representation.
      */

--- a/contracts/VoucherHub.sol
+++ b/contracts/VoucherHub.sol
@@ -107,7 +107,7 @@ contract VoucherHub is
      * This function only updates the duration for newly minted vouchers and not the existing ones to provide
      * guarantees regarding the expiration of vouchers. When a voucher is delivered, its credits should not expire
      * before the original expiration date.
-     * This is not a bug as mentioned in audit of Halborn (HAL-01) but an intended feature.
+     * As mentioned in Halborn audit report (HAL-01), this is not a bug, but rather, an intended feature.
      */
     function updateVoucherTypeDescription(
         uint256 id,

--- a/contracts/VoucherHub.sol
+++ b/contracts/VoucherHub.sol
@@ -104,9 +104,9 @@ contract VoucherHub is
     }
 
     /**
-     * This function updates only the duration setting for the next minted voucher and not the active one.
-     * The manager of vouchers wants to provide guarantees regarding the expiration of a voucher.
-     * When a voucher is delivered, the credits inside the voucher should not expire before the original expiration date.
+     * This function only updates the duration for newly minted vouchers and not the existing ones to provide
+     * guarantees regarding the expiration of vouchers. When a voucher is delivered, its credits should not expire
+     * before the original expiration date.
      */
     function updateVoucherTypeDescription(
         uint256 id,

--- a/contracts/VoucherHub.sol
+++ b/contracts/VoucherHub.sol
@@ -107,6 +107,7 @@ contract VoucherHub is
      * This function only updates the duration for newly minted vouchers and not the existing ones to provide
      * guarantees regarding the expiration of vouchers. When a voucher is delivered, its credits should not expire
      * before the original expiration date.
+     * This is not a bug as mentioned in audit of Halborn (HAL-01) but an intended feature.
      */
     function updateVoucherTypeDescription(
         uint256 id,

--- a/contracts/VoucherHub.sol
+++ b/contracts/VoucherHub.sol
@@ -103,6 +103,11 @@ contract VoucherHub is
         emit VoucherTypeCreated($._voucherTypes.length - 1, description, duration);
     }
 
+    /**
+     * This function updates only the duration setting for the next minted voucher and not the active one.
+     * The manager of vouchers wants to provide guarantees regarding the expiration of a voucher.
+     * When a voucher is delivered, the credits inside the voucher should not expire before the original expiration date.
+     */
     function updateVoucherTypeDescription(
         uint256 id,
         string memory description

--- a/docs/VoucherHub.md
+++ b/docs/VoucherHub.md
@@ -57,6 +57,10 @@ function createVoucherType(string description, uint256 duration) external
 function updateVoucherTypeDescription(uint256 id, string description) external
 ```
 
+This function updates only the duration setting for the next minted voucher and not the active one.
+The manager of vouchers wants to provide guarantees regarding the expiration of a voucher.
+When a voucher is delivered, the credits inside the voucher should not expire before the original expiration date.
+
 ### updateVoucherTypeDuration
 
 ```solidity

--- a/docs/VoucherHub.md
+++ b/docs/VoucherHub.md
@@ -60,6 +60,7 @@ function updateVoucherTypeDescription(uint256 id, string description) external
 This function only updates the duration for newly minted vouchers and not the existing ones to provide
 guarantees regarding the expiration of vouchers. When a voucher is delivered, its credits should not expire
 before the original expiration date.
+This is not a bug as mentioned in audit of Halborn (HAL-01) but an intended feature.
 
 ### updateVoucherTypeDuration
 

--- a/docs/VoucherHub.md
+++ b/docs/VoucherHub.md
@@ -57,9 +57,9 @@ function createVoucherType(string description, uint256 duration) external
 function updateVoucherTypeDescription(uint256 id, string description) external
 ```
 
-This function updates only the duration setting for the next minted voucher and not the active one.
-The manager of vouchers wants to provide guarantees regarding the expiration of a voucher.
-When a voucher is delivered, the credits inside the voucher should not expire before the original expiration date.
+This function only updates the duration for newly minted vouchers and not the existing ones to provide
+guarantees regarding the expiration of vouchers. When a voucher is delivered, its credits should not expire
+before the original expiration date.
 
 ### updateVoucherTypeDuration
 

--- a/docs/VoucherHub.md
+++ b/docs/VoucherHub.md
@@ -60,7 +60,7 @@ function updateVoucherTypeDescription(uint256 id, string description) external
 This function only updates the duration for newly minted vouchers and not the existing ones to provide
 guarantees regarding the expiration of vouchers. When a voucher is delivered, its credits should not expire
 before the original expiration date.
-This is not a bug as mentioned in audit of Halborn (HAL-01) but an intended feature.
+As mentioned in Halborn audit report (HAL-01), this is not a bug, but rather, an intended feature.
 
 ### updateVoucherTypeDuration
 

--- a/test/VoucherHub.test.ts
+++ b/test/VoucherHub.test.ts
@@ -78,15 +78,6 @@ describe('VoucherHub', function () {
         };
     }
 
-    describe('Decimals', function () {
-        it('Should return 9 as the number of decimals', async function () {
-            const { voucherHub } = await loadFixture(deployFixture);
-
-            // Call the decimals function and check the returned value
-            expect(await voucherHub.decimals()).to.equal(9);
-        });
-    });
-
     describe('Initialize', function () {
         it('Should initialize', async function () {
             const { beacon, voucherHub, admin, manager, minter } = await loadFixture(deployFixture);
@@ -1072,6 +1063,13 @@ describe('VoucherHub', function () {
             await expect(voucherHub.transferFrom(anyone, anyone, 0)).to.be.revertedWith(
                 'NonTransferableERC20Upgradeable: Unsupported transferFrom',
             );
+        });
+
+        it('Should return 9 as the number of decimals', async function () {
+            const { voucherHub } = await loadFixture(deployFixture);
+
+            // Call the decimals function and check the returned value
+            expect(await voucherHub.decimals()).to.equal(9);
         });
     });
 });

--- a/test/VoucherHub.test.ts
+++ b/test/VoucherHub.test.ts
@@ -83,10 +83,7 @@ describe('VoucherHub', function () {
             const { voucherHub } = await loadFixture(deployFixture);
 
             // Call the decimals function and check the returned value
-            const decimals = await voucherHub.decimals();
-
-            // Assertion to check if the returned decimals value is 9
-            expect(decimals).to.equal(9);
+            expect(await voucherHub.decimals()).to.equal(9);
         });
     });
 

--- a/test/VoucherHub.test.ts
+++ b/test/VoucherHub.test.ts
@@ -78,6 +78,18 @@ describe('VoucherHub', function () {
         };
     }
 
+    describe('Decimals', function () {
+        it('Should return 9 as the number of decimals', async function () {
+            const { voucherHub } = await loadFixture(deployFixture);
+
+            // Call the decimals function and check the returned value
+            const decimals = await voucherHub.decimals();
+
+            // Assertion to check if the returned decimals value is 9
+            expect(decimals).to.equal(9);
+        });
+    });
+
     describe('Initialize', function () {
         it('Should initialize', async function () {
             const { beacon, voucherHub, admin, manager, minter } = await loadFixture(deployFixture);


### PR DESCRIPTION
- [x] Add commentary regarding the Halborn audit report, mentioning informational feedback about the `updateVoucherTypeDuration` function.  
- [x] Override the `decimals` function of ERC-20 to set the token's decimal precision to 9, aligning with RLC standards.  